### PR TITLE
VAM-002: shared build settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,91 @@
+# EditorConfig for VirtualAudioMixer
+#
+# Covers whitespace, line endings and encoding for every file, plus the C#
+# code-style rules the project enforces at build time (see CONTRIBUTING.md).
+# Enforcement is Roslyn's built-in analyzers only -- there is no third-party
+# style analyzer in the tree.
+
+root = true
+
+###############################################################################
+# All files: whitespace, line endings, encoding
+###############################################################################
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{csproj,props,targets,xml}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+###############################################################################
+# C# code style -- enforced as build errors
+###############################################################################
+[*.cs]
+
+# File-scoped namespaces
+csharp_style_namespace_declarations = file_scoped:error
+
+# Explicit types, never 'var'
+csharp_style_var_for_built_in_types = false:error
+csharp_style_var_when_type_is_apparent = false:error
+csharp_style_var_elsewhere = false:error
+
+# Always use braces
+csharp_prefer_braces = true:error
+
+# Omit redundant accessibility modifiers (drop an explicit 'private')
+dotnet_style_require_accessibility_modifiers = omit_if_default:error
+
+# Modifier order
+csharp_preferred_modifier_order = public, protected, internal, private, new, abstract, virtual, override, sealed, static, readonly, extern, unsafe, volatile, async:error
+
+# using directives: System namespaces first, placed outside the namespace
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+csharp_using_directive_placement = outside_namespace:error
+
+# Promote the matching IDE analyzers to build errors
+dotnet_diagnostic.IDE0007.severity = error   # use explicit type instead of 'var'
+dotnet_diagnostic.IDE0008.severity = error   # use explicit type instead of 'var'
+dotnet_diagnostic.IDE0011.severity = error   # add braces
+dotnet_diagnostic.IDE0036.severity = error   # order modifiers
+dotnet_diagnostic.IDE0040.severity = error   # accessibility modifiers
+dotnet_diagnostic.IDE0065.severity = error   # using directive placement
+dotnet_diagnostic.IDE0161.severity = error   # file-scoped namespace
+
+# Async methods must end in 'Async'
+dotnet_diagnostic.VSTHRD200.severity = error
+
+###############################################################################
+# Naming
+###############################################################################
+
+# Private / internal fields: camelCase, no underscore prefix
+dotnet_naming_rule.non_public_fields_camel_case.severity = error
+dotnet_naming_rule.non_public_fields_camel_case.symbols = non_public_fields
+dotnet_naming_rule.non_public_fields_camel_case.style = camel_case
+
+dotnet_naming_symbols.non_public_fields.applicable_kinds = field
+dotnet_naming_symbols.non_public_fields.applicable_accessibilities = private, internal, private_protected
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+# Types and non-field members: PascalCase
+dotnet_naming_rule.types_and_members_pascal_case.severity = error
+dotnet_naming_rule.types_and_members_pascal_case.symbols = types_and_members
+dotnet_naming_rule.types_and_members_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.types_and_members.applicable_kinds = class, struct, interface, enum, property, method, event, delegate
+dotnet_naming_symbols.types_and_members.applicable_accessibilities = *
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,19 @@ cannot be relicensed later without asking you.
 
 ## Style
 
-Match the code around you. There are no analyzers and no warnings-as-errors, and
-none are wanted — the audio-path rule above is the only hard constraint, and it is
-about behaviour rather than formatting.
+Style is enforced at build time, not left to habit. The build treats warnings as
+errors (`TreatWarningsAsErrors`) and runs Roslyn's built-in code-style analyzers
+as part of compilation (`EnforceCodeStyleInBuild`), configured in `.editorconfig`;
+the `...Async` suffix is enforced by the Microsoft.VisualStudio.Threading
+analyzers. There is no third-party style analyzer in the tree — the dedicated one
+for these guidelines is no longer maintained — so the build enforces the subset it
+can (explicit types over `var`, file-scoped namespaces, braces, modifier order,
+accessibility, field naming, the async suffix) and the rest is convention: write
+C# to the [C# Coding Guidelines](https://csharpcodingguidelines.com/) and match the
+code around you.
+
+The audio-path rule above remains the only hard *behavioural* constraint; the
+style rules here are about form.
 
 ## Testing
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Deterministic>true</Deterministic>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+  </ItemGroup>
+
+</Project>

--- a/src/Vam.Client/Vam.Client.csproj
+++ b/src/Vam.Client/Vam.Client.csproj
@@ -1,9 +1,3 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
 </Project>

--- a/src/Vam.Engine/Vam.Engine.csproj
+++ b/src/Vam.Engine/Vam.Engine.csproj
@@ -1,9 +1,3 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
 </Project>

--- a/src/Vam.Protocol/Vam.Protocol.csproj
+++ b/src/Vam.Protocol/Vam.Protocol.csproj
@@ -1,9 +1,3 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
 </Project>

--- a/src/Vam.Ui/Vam.Ui.csproj
+++ b/src/Vam.Ui/Vam.Ui.csproj
@@ -1,9 +1,3 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
 </Project>

--- a/tests/Vam.Engine.Tests/Vam.Engine.Tests.csproj
+++ b/tests/Vam.Engine.Tests/Vam.Engine.Tests.csproj
@@ -1,9 +1,3 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
 </Project>

--- a/tests/Vam.TestKit/Vam.TestKit.csproj
+++ b/tests/Vam.TestKit/Vam.TestKit.csproj
@@ -1,9 +1,3 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
 </Project>


### PR DESCRIPTION
Implements **VAM-002 Shared build settings** (#5).

## What changed
- **`Directory.Build.props`** (root) — centralises `TargetFramework` (net10.0), `Nullable`, `ImplicitUsings`, `Deterministic`, `LangVersion`, plus `TreatWarningsAsErrors` and `EnforceCodeStyleInBuild`, and references the threading analyzer for all projects.
- **`Directory.Packages.props`** (root) — `ManagePackageVersionsCentrally`; the one place package versions live (currently just `Microsoft.VisualStudio.Threading.Analyzers`).
- **`.editorconfig`** (root) — whitespace / line endings / encoding, plus the C# code-style rules enforced as build errors (no `var`, file-scoped namespaces, braces, modifier order, accessibility, field naming, `...Async` suffix via VSTHRD200).
- Stripped all six `.csproj` files down to `<Project Sdk="Microsoft.NET.Sdk"></Project>`.
- **`CONTRIBUTING.md`** — rewrote the *Style* section to match: warnings-as-errors and built-in code-style enforcement are now the policy.

## Deviation from the issue as originally written
Issue #5 originally forbade analyzers and warnings-as-errors. Per an explicit maintainer decision this is reversed: the build now treats warnings as errors and enforces C# style. The dedicated analyzer for these guidelines (CSharpGuidelinesAnalyzer) is archived/unmaintained, so enforcement uses Roslyn built-ins plus the threading analyzer, and the rest of the guidelines remain authoring conventions. The issue's Constraints / Acceptance criteria / Verification are superseded accordingly (see issue comment).

## Verification
- No `.csproj` under `src`/`tests` sets a target framework, nullable or language version — only `Directory.Build.props` does.
- Package versions appear in exactly one file (`Directory.Packages.props`).
- `dotnet build VirtualAudioMixer.sln -c Release` → **0 warnings, 0 errors** (with warnings-as-errors active).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
